### PR TITLE
Fix deps for top-level dependencies

### DIFF
--- a/src/RPMmd.jl
+++ b/src/RPMmd.jl
@@ -279,6 +279,7 @@ function deps(pkg::Union(Package,Packages))
     else
         packages = ParsedData[pkg.pd,]
     end
+    packages = union(packages, add.p)
     while !isempty(add)
         reqs = setdiff(rpm_requires(add), reqd)
         append!(reqd,reqs)


### PR DESCRIPTION
Currently, deps only returns sub-depencies of the
dependencies of the specified package.

For example, deps(fontconfig) should show libgcc, libxml, and freetype.
Without this patch, deps(fontconfig) shows only zlib.
