### PR TITLE
only require httpclient on unix

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.2-
 URLParse 0.0.0
-HTTPClient 0.0.0
+@unix HTTPClient 0.0.0
 LibExpat 0.0.3
 Zlib 0.1.4


### PR DESCRIPTION
This is only being used for Unix platforms, and since HTTPClient depends on LibCURL which uses WinRPM to download the library, it breaks a circular dependency and simplifies installation on Windows.
