### PR TITLE
WIP/RFC: Migrate away from Zlib

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ Compat 0.7.20
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
 LibExpat 0.0.3
-Zlib 0.1.4
+Libz
 BinDeps 0.3
 SHA
 LegacyStrings

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -7,7 +7,7 @@ if is_unix()
     using HTTPClient.HTTPC
 end
 
-using Zlib
+using Libz
 using LibExpat
 using URIParser
 using LegacyStrings
@@ -155,7 +155,7 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
                 warn("received error $(data[2]) while downloading $source/$path")
                 return nothing
             end
-            body = gunzip ? decompress(data[1]) : data[1]
+            body = gunzip ? decompress(convert(Vector{UInt8},data[1])) : data[1]
             open(path2, "w") do f
                 write(f, body)
             end

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -155,7 +155,7 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
                 warn("received error $(data[2]) while downloading $source/$path")
                 return nothing
             end
-            body = gunzip ? decompress(convert(Vector{UInt8},data[1])) : data[1]
+            body = gunzip ? Libz.decompress(convert(Vector{UInt8},data[1])) : data[1]
             open(path2, "w") do f
                 write(f, body)
             end


### PR DESCRIPTION
This PR attempts to migrate away from Zlib.jl to its replacement Libz.jl. Fixes #84. 

Currently, not sure if this is the appropriate fix. Is there a way I can test whether this works? There's no runtests.jl file for this package too.

cc: @tkelman 