### PR TITLE
Fix couple of warnings

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -343,7 +343,7 @@ end
 deps(pkg::AbstractString, arch::AbstractString=OS_ARCH) = deps(select(lookup(pkg, arch), pkg))
 @compat function deps(pkg::Union{Package,Packages})
     add = rpm_provides(rpm_requires(pkg))
-    packages::Vector{ParsedData}
+    local packages::Vector{ParsedData}
     reqd = AbstractString[]
     if isa(pkg,Packages)
         packages = ParsedData[p for p in pkg.p]

--- a/src/winrpm_bindeps.jl
+++ b/src/winrpm_bindeps.jl
@@ -4,7 +4,7 @@ using BinDeps
 import BinDeps: PackageManager, can_use, package_available, available_version,
     libdir, generate_steps, LibraryDependency, provider, provides, pkg_name
 
-update_once = true
+update_once = true::Bool
 
 type RPM <: PackageManager
     package
@@ -12,7 +12,7 @@ end
 
 can_use(::Type{RPM}) = is_windows()
 function package_available(p::RPM)
-    global update_once::Bool
+    global update_once
     !can_use(RPM) && return false
     pkgs = p.package
     if isa(pkgs,AbstractString)

--- a/src/winrpm_bindeps.jl
+++ b/src/winrpm_bindeps.jl
@@ -4,7 +4,7 @@ using BinDeps
 import BinDeps: PackageManager, can_use, package_available, available_version,
     libdir, generate_steps, LibraryDependency, provider, provides, pkg_name
 
-update_once = true::Bool
+update_once = true
 
 type RPM <: PackageManager
     package


### PR DESCRIPTION
This PR tries to fix

```
WARNING: deprecated syntax "packages::Core.apply_type(Vector,ParsedData)".
Use "local packages::Core.apply_type(Vector,ParsedData)" instead.

WARNING: deprecated syntax "global update_once::Bool".
Use "typeassert" instead.
``` 

that comes up while doing `using WinRPM`. Not sure if these are the right fixes