### PR TITLE
Update to using instead of import for Compat

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -1,7 +1,7 @@
 module WinRPM
 
 using Compat
-import Compat: String, KERNEL
+using Compat: String, KERNEL
 
 if is_unix()
     using HTTPClient.HTTPC


### PR DESCRIPTION
Since we don't extend any of the methods.