### PR TITLE
Update deprecated LibExpat method ParsedData to ETree and minimum version # for dep warns in other packages

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -51,7 +51,7 @@ if is_unix()
     end
 elseif is_windows()
     function download(source::AbstractString; retry=5)
-        dest = Array(UInt16,261)
+        dest = Vector{UInt16}(261)
         for i in 1:retry
             res = ccall((:URLDownloadToCacheFileW, :urlmon), stdcall, Cuint,
               (Ptr{Void}, Ptr{UInt16}, Ptr{UInt16}, Clong, Cint, Ptr{Void}),

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -25,7 +25,7 @@ function mkdirs(dir)
     end
 end
 
-global const packages = ParsedData[]
+global const packages = ETree[]
 
 function __init__()
     empty!(packages)
@@ -192,17 +192,17 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
 end
 
 immutable Package
-    pd::ParsedData
+    pd::ETree
 end
 Package(p::Package) = p
-Package(p::Vector{ParsedData}) = [Package(pkg) for pkg in p]
+Package(p::Vector{ETree}) = [Package(pkg) for pkg in p]
 
 getindex(pkg::Package,x) = getindex(pkg.pd, x)
 
-@compat immutable Packages{T<:Union{Set{ParsedData},Vector{ParsedData},}}
+@compat immutable Packages{T<:Union{Set{ETree},Vector{ETree},}}
     p::T
 end
-@compat Packages{T<:Union{Set{ParsedData},Vector{ParsedData}}}(pkgs::T) = Packages{T}(pkgs)
+@compat Packages{T<:Union{Set{ETree},Vector{ETree}}}(pkgs::T) = Packages{T}(pkgs)
 Packages(pkgs::Vector{Package}) = Packages([p.pd for p in pkgs])
 Packages(xpath::LibExpat.XPath) = Packages(packages[xpath])
 
@@ -280,7 +280,7 @@ rpm_provides(requires::AbstractString) =
     Packages(xpath".[format/rpm:provides/rpm:entry[@name='$requires']]")
 
 @compat function rpm_provides{T<:AbstractString}(requires::Union{Vector{T},Set{T}})
-    pkgs = Set{ParsedData}()
+    pkgs = Set{ETree}()
     for x in requires
         pkgs_ = rpm_provides(x)
         if isempty(pkgs_)
@@ -309,7 +309,7 @@ function rpm_url(pkg::Package)
     url = baseurl, href
 end
 
-@compat function rpm_ver(pkg::Union{Package,ParsedData})
+@compat function rpm_ver(pkg::Union{Package,ETree})
     return (pkg[xpath"version/@ver"][1],
             pkg[xpath"version/@rel"][1],
             pkg[xpath"version/@epoch"][1])
@@ -338,12 +338,12 @@ end
 deps(pkg::AbstractString, arch::AbstractString=OS_ARCH) = deps(select(lookup(pkg, arch), pkg))
 @compat function deps(pkg::Union{Package,Packages})
     add = rpm_provides(rpm_requires(pkg))
-    local packages::Vector{ParsedData}
+    local packages::Vector{ETree}
     reqd = AbstractString[]
     if isa(pkg, Packages)
-        packages = ParsedData[p for p in pkg.p]
+        packages = ETree[p for p in pkg.p]
     else
-        packages = ParsedData[pkg.pd]
+        packages = ETree[pkg.pd]
     end
     packages = union(packages, add.p)
     while !isempty(add)
@@ -405,7 +405,7 @@ end
                 push!(installed_list, ln)
             end
         end
-        toupdate = ParsedData[]
+        toupdate = ETree[]
         filter!(packages) do p
             ver = replace(join(rpm_ver(p), ','), r"\s", "")
             oldver = false

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -80,7 +80,7 @@ function getcachedir(cachedir, source)
         lines = readlines(cacheindex)
         for (idx,line) in enumerate(lines)
             if !startswith(line,'#') && ' ' in line
-                stri, src = @compat split(chomp(line), ' ', limit=2)
+                stri, src = split(chomp(line), ' ', limit=2)
                 cache = joinpath(cachedir, stri)
                 if !isdir(cache)
                     # remove this directory from the list,
@@ -173,7 +173,7 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
                 for pkg in pkgs[xpath".[arch='noarch' or arch='src'][starts-with(name,'mingw32-') or starts-with(name, 'mingw64-')]"]
                     name = pkg[xpath"name"][1]
                     arch = pkg[xpath"arch"][1]
-                    new_arch, new_name = @compat split(LibExpat.string_value(name), '-', limit=2)
+                    new_arch, new_name = split(LibExpat.string_value(name), '-', limit=2)
                     old_arch = LibExpat.string_value(arch)
                     if old_arch != "noarch"
                         new_arch = "$new_arch-$old_arch"
@@ -199,10 +199,9 @@ Package(p::Vector{ETree}) = [Package(pkg) for pkg in p]
 
 getindex(pkg::Package,x) = getindex(pkg.pd, x)
 
-@compat immutable Packages{T<:Union{Set{ETree},Vector{ETree},}}
+immutable Packages{T<:Union{Set{ETree},Vector{ETree}}}
     p::T
 end
-@compat Packages{T<:Union{Set{ETree},Vector{ETree}}}(pkgs::T) = Packages{T}(pkgs)
 Packages(pkgs::Vector{Package}) = Packages([p.pd for p in pkgs])
 Packages(xpath::LibExpat.XPath) = Packages(packages[xpath])
 
@@ -279,7 +278,7 @@ whatprovides(file::AbstractString, arch::AbstractString=OS_ARCH) =
 rpm_provides(requires::AbstractString) =
     Packages(xpath".[format/rpm:provides/rpm:entry[@name='$requires']]")
 
-@compat function rpm_provides{T<:AbstractString}(requires::Union{Vector{T},Set{T}})
+function rpm_provides{T<:AbstractString}(requires::Union{Vector{T},Set{T}})
     pkgs = Set{ETree}()
     for x in requires
         pkgs_ = rpm_provides(x)
@@ -294,7 +293,7 @@ end
 
 rpm_requires(x::Package) = x[xpath"format/rpm:requires/rpm:entry/@name"]
 
-@compat function rpm_requires(xs::Union{Vector{Package},Set{Package},Packages})
+function rpm_requires(xs::Union{Vector{Package},Set{Package},Packages})
     requires = Set{AbstractString}()
     for x in xs
         union!(requires, rpm_requires(x))
@@ -309,7 +308,7 @@ function rpm_url(pkg::Package)
     url = baseurl, href
 end
 
-@compat function rpm_ver(pkg::Union{Package,ETree})
+function rpm_ver(pkg::Union{Package,ETree})
     return (pkg[xpath"version/@ver"][1],
             pkg[xpath"version/@rel"][1],
             pkg[xpath"version/@epoch"][1])
@@ -336,7 +335,7 @@ function getepoch(pkg::Package)
 end
 
 deps(pkg::AbstractString, arch::AbstractString=OS_ARCH) = deps(select(lookup(pkg, arch), pkg))
-@compat function deps(pkg::Union{Package,Packages})
+function deps(pkg::Union{Package,Packages})
     add = rpm_provides(rpm_requires(pkg))
     local packages::Vector{ETree}
     reqd = AbstractString[]
@@ -367,7 +366,7 @@ function install{T<:AbstractString}(pkgs::Vector{T}, arch::AbstractString=OS_ARC
     install(Packages(todo); yes=yes)
 end
 
-@compat function install(pkg::Union{Package,Packages}; yes=false)
+function install(pkg::Union{Package,Packages}; yes=false)
     todo, toup = prepare_install(pkg)
     if isempty(todo) && isempty(toup)
         info("Nothing to do")
@@ -394,13 +393,13 @@ end
     end
 end
 
-@compat function prepare_install(pkg::Union{Package,Packages})
+function prepare_install(pkg::Union{Package,Packages})
     packages = deps(pkg).p
     open(installedlist, isfile(installedlist)?"r+":"w+") do installed
         seek(installed, 0)
         installed_list = Vector{AbstractString}[]
         for line in eachline(installed)
-            ln = @compat split(chomp(line), ' ', limit=2)
+            ln = split(chomp(line), ' ', limit=2)
             if length(ln) == 2
                 push!(installed_list, ln)
             end


### PR DESCRIPTION
Needs a bump in LibExpat require after the macro hygiene bugfix


