### PR TITLE
Remove global keyword of global packages variable

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -25,7 +25,7 @@ function mkdirs(dir)
     end
 end
 
-global const packages = ETree[]
+const packages = ETree[]
 
 function __init__()
     empty!(packages)


### PR DESCRIPTION
It is unnecessary (looks like this was from 3 years ago)