### PR TITLE
Do not print ending newline in `show` methods

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -221,19 +221,19 @@ function show(io::IO, pkg::Package)
     println(io,"  Arch: ", LibExpat.string_value(pkg["arch"][1]))
     println(io,"  URL: ", LibExpat.string_value(pkg["url"][1]))
     println(io,"  License: ", LibExpat.string_value(pkg["format/rpm:license"][1]))
-    println(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
+    print(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
 end
 
 function show(io::IO, pkgs::Packages)
-    println(io, "WinRPM Package Set:")
+    print(io, "WinRPM Package Set:")
     if isempty(pkgs)
-        println(io, "  <empty>")
+        print(io, "\n  <empty>")
     else
         for (i,pkg) = enumerate(pkgs)
             name = names(pkg)
             summary = LibExpat.string_value(pkg["summary"][1])
             arch = LibExpat.string_value(pkg["arch"][1])
-            println(io,"  $i. $name ($arch) - $summary")
+            print(io,"\n  $i. $name ($arch) - $summary")
         end
     end
 end


### PR DESCRIPTION
This makes things consistent with base in which types do not have have an end line additionally printed.
In the REPL endline `\n` is automatically added.

(with this patch)
```julia
julia> WinRPM.search("gcc")
WinRPM Package Set:
  1. gcc (mingw64) - MinGW Windows compiler (GCC) for C
  2. gcc-c++ (mingw64) - MinGW Windows compiler for C++
  3. gcc-debug (mingw64) - Debug information for package mingw64-gcc
  4. gcc-debugsource (mingw64) - Debug sources for package mingw64-gcc
  5. gcc-fortran (mingw64) - MinGW Windows compiler for Fortran
  6. gcc-objc (mingw64) - MinGW Windows compiler for Objective-C and Objective-C++
  7. libgcc_s_seh1 (mingw64) - MinGW Windows compiler for C shared libraries

julia>
julia> WinRPM.search("")
WinRPM Package Set:
  <empty>

julia>
```
as opposed to
```julia
julia> WinRPM.search("gcc")
WinRPM Package Set:
  1. gcc (mingw64) - MinGW Windows compiler (GCC) for C
  2. gcc-c++ (mingw64) - MinGW Windows compiler for C++
  3. gcc-debug (mingw64) - Debug information for package mingw64-gcc
  4. gcc-debugsource (mingw64) - Debug sources for package mingw64-gcc
  5. gcc-fortran (mingw64) - MinGW Windows compiler for Fortran
  6. gcc-objc (mingw64) - MinGW Windows compiler for Objective-C and Objective-C++
  7. libgcc_s_seh1 (mingw64) - MinGW Windows compiler for C shared libraries


julia>
julia> WinRPM.search("")
WinRPM Package Set:
  <empty>


julia>
```