### PR TITLE
Adding non-cached links to sources.list

### DIFF
--- a/sources.list
+++ b/sources.list
@@ -1,2 +1,4 @@
 https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.2
 https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.2
+http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.2
+http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.2


### PR DESCRIPTION
WinRPM is encountering download errors because cached links are failing on some Windows servers,  removing the caching resolves this issue on those servers. So, this PR provides non-cached links as alternative whenever cached links fail.