### PR TITLE
Do not print ending newline in show methods. This changes the show me…

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -223,19 +223,19 @@ function show(io::IO, pkg::Package)
     println(io,"  Arch: ", LibExpat.string_value(pkg["arch"][1]))
     println(io,"  URL: ", LibExpat.string_value(pkg["url"][1]))
     println(io,"  License: ", LibExpat.string_value(pkg["format/rpm:license"][1]))
-    println(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
+    print(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
 end
 
 function show(io::IO, pkgs::Packages)
-    println(io, "WinRPM Package Set:")
+    print(io, "WinRPM Package Set:")
     if isempty(pkgs)
-        println(io, "  <empty>")
+        print(io, "\n  <empty>")
     else
         for (i,pkg) = enumerate(pkgs)
             name = names(pkg)
             summary = LibExpat.string_value(pkg["summary"][1])
             arch = LibExpat.string_value(pkg["arch"][1])
-            println(io,"  $i. $name ($arch) - $summary")
+            print(io,"\n  $i. $name ($arch) - $summary")
         end
     end
 end


### PR DESCRIPTION
…thods to be consistent with printing in Base Julia where extra endlines are not printed

Before:
![image](https://user-images.githubusercontent.com/4319522/32446843-31741f84-c2d8-11e7-9d80-5a26cd1322bf.png)

After:
![image](https://user-images.githubusercontent.com/4319522/32446870-4fcf7a50-c2d8-11e7-8d9e-f4a26d834c25.png)


cc @ararslan  @tkelman 

rebase of https://github.com/JuliaPackaging/WinRPM.jl/pull/111
