### PR TITLE
JULIA_HOME is no longer defined

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.30.0
+Compat 0.42.0
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
 LibExpat 0.2.8

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -3,7 +3,7 @@ __precompile__()
 module WinRPM
 
 using Compat
-using Compat.Sys: iswindows, isunix
+using Compat.Sys: iswindows, isunix, BINDIR
 
 if isunix()
     using HTTPClient.HTTPC
@@ -446,7 +446,7 @@ function do_install(packages::Packages)
     end
 end
 
-const exe7z = iswindows() ? joinpath(JULIA_HOME, "7z.exe") : "7z"
+const exe7z = iswindows() ? joinpath(BINDIR, "7z.exe") : "7z"
 
 function do_install(package::Package)
     name = names(package)


### PR DESCRIPTION
JULIA_HOME is no longer defined which results in build errors. I updated usage to Compat.Sys.BINDIR.