### PR TITLE
Map isless(a,b) to <(a,b)

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -326,6 +326,7 @@ Base.:(<=)(a::RPMVersionNumber, b::RPMVersionNumber) = (a == b) || (a < b)
 Base.:(>)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a <= b)
 Base.:(>=)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a < b)
 Base.:(!=)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a == b)
+Base.isless(a::RPMVersionNumber, b::RPMVersionNumber) = (a < b)
 
 function getepoch(pkg::Package)
     epoch = pkg[xpath"version/@epoch"]


### PR DESCRIPTION
To fix #138 and ensure no breakage mapping an isless call to less than.  