### PR TITLE
Fix issue with .7 where 7zip extracts the file without the noarch%2F on it

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -223,19 +223,19 @@ function show(io::IO, pkg::Package)
     println(io,"  Arch: ", LibExpat.string_value(pkg["arch"][1]))
     println(io,"  URL: ", LibExpat.string_value(pkg["url"][1]))
     println(io,"  License: ", LibExpat.string_value(pkg["format/rpm:license"][1]))
-    println(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
+    print(io,"  Description: ", replace(LibExpat.string_value(pkg["description"][1]), r"\r\n|\r|\n", "\n    "))
 end
 
 function show(io::IO, pkgs::Packages)
-    println(io, "WinRPM Package Set:")
+    print(io, "WinRPM Package Set:")
     if isempty(pkgs)
-        println(io, "  <empty>")
+        print(io, "\n  <empty>")
     else
         for (i,pkg) = enumerate(pkgs)
             name = names(pkg)
             summary = LibExpat.string_value(pkg["summary"][1])
             arch = LibExpat.string_value(pkg["arch"][1])
-            println(io,"  $i. $name ($arch) - $summary")
+            print(io,"\n  $i. $name ($arch) - $summary")
         end
     end
 end

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -326,6 +326,7 @@ Base.:(<=)(a::RPMVersionNumber, b::RPMVersionNumber) = (a == b) || (a < b)
 Base.:(>)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a <= b)
 Base.:(>=)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a < b)
 Base.:(!=)(a::RPMVersionNumber, b::RPMVersionNumber) = !(a == b)
+Base.isless(a::RPMVersionNumber, b::RPMVersionNumber) = (a < b)
 
 function getepoch(pkg::Package)
     epoch = pkg[xpath"version/@epoch"]

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -464,7 +464,13 @@ function do_install(package::Package)
         write(f, data[1])
     end
     info("Extracting: ", name)
-    cpio = splitext(path2)[1]*".cpio"
+    
+    @static if VERSION < v"0.7.0-DEV"
+        cpio = splitext(path2)[1]*".cpio"
+    else
+        cpio = splitext(joinpath(cache, escape(last(split(path, "/")))))[1] * ".cpio"
+    end
+
     local err = nothing
     for cmd = [`$exe7z x -y $path2 -o$cache`, `$exe7z x -y $cpio -o$installdir`]
         (out, pc) = open(cmd, "r")

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -13,7 +13,7 @@ using Libz, LibExpat, URIParser
 
 import Base: show, getindex, wait_close, pipeline_error
 
-#export update, whatprovides, search, lookup, install, deps, help
+#export update, whatprovides, search, lookup, install, deps
 
 if iswindows()
     const OS_ARCH = Sys.WORD_SIZE == 64 ? "mingw64" : "mingw32"
@@ -510,10 +510,9 @@ function prompt_ok(question)
     end
 end
 
-function help()
-    less(joinpath(dirname(dirname(@__FILE__)), "README.md"))
-end
-
 include("winrpm_bindeps.jl")
+
+# deprecations 
+@deprecate help() "Please see the README.md file at https://github.com/JuliaPackaging/WinRPM.jl"
 
 end


### PR DESCRIPTION
This should fix #134 as well as any issue where WinRPM was failing to find the extracted cpio file from an rpm file.   See #134 for a full discussion of why this was happening in .7.   

This along with #136 & #139 should restore WinRPM to working condition in .7.  However, the package produces a large number of warnings and a deprecation errors so this might change as .7 matures.

I am not sure if my @static if VERSION < v"0.7.0-DEV" is the proper way to fence off .7 code from .6 code.   If not please let me know.  I have tested this on both .7 and .6 and with this code in place files download, extract, and install successfully. 

After looking this fix might be a duplicate of #137 as the problem looks the same but I did not look in depth at it.  

