### PR TITLE
Fix issue with .7 where 7zip extracts the file without the noarch%2F on it (Take2)

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -463,7 +463,13 @@ function do_install(package::Package)
         write(f, data[1])
     end
     info("Extracting: ", name)
-    cpio = splitext(path2)[1]*".cpio"
+
+    @static if VERSION < v"0.7.0-DEV"
+        cpio = splitext(path2)[1]*".cpio"
+    else
+        cpio = splitext(joinpath(cache, escape(last(split(path, "/")))))[1] * ".cpio"
+    end
+
     local err = nothing
     for cmd = [`$exe7z x -y $path2 -o$cache`, `$exe7z x -y $cpio -o$installdir`]
         (out, pc) = open(cmd, "r")

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -464,7 +464,7 @@ function do_install(package::Package)
     end
     info("Extracting: ", name)
 
-    @static if VERSION < v"0.7.0-DEV"
+    @static if VERSION < v"0.7.0-DEV.2181"
         cpio = splitext(path2)[1]*".cpio"
     else
         cpio = splitext(joinpath(cache, escape(last(split(path, "/")))))[1] * ".cpio"

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -467,7 +467,7 @@ function do_install(package::Package)
     if VERSION < v"0.7.0-DEV.2181"
         cpio = splitext(path2)[1]*".cpio"
     else
-        cpio = splitext(joinpath(cache, escape(last(split(path, "/")))))[1] * ".cpio"
+        cpio = splitext(joinpath(cache, escape(basename(path))))[1] * ".cpio"
     end
 
     local err = nothing

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -464,7 +464,7 @@ function do_install(package::Package)
     end
     info("Extracting: ", name)
 
-    @static if VERSION < v"0.7.0-DEV.2181"
+    if VERSION < v"0.7.0-DEV.2181"
         cpio = splitext(path2)[1]*".cpio"
     else
         cpio = splitext(joinpath(cache, escape(last(split(path, "/")))))[1] * ".cpio"


### PR DESCRIPTION
This should fix #134 as well as any issue where WinRPM was failing to find the extracted cpio file from an rpm file.   See #134 for a full discussion of why this was happening in .7.   

This along with #136 & #139 should restore WinRPM to working condition in .7.  However, the package produces a large number of warnings and a deprecation errors so this might change as .7 matures.

I am not sure if my @static if VERSION < v"0.7.0-DEV" is the proper way to fence off .7 code from .6 code.   If not please let me know.  I have tested this on both .7 and .6 and with this code in place files download, extract, and install successfully. 

After looking this fix might be a duplicate of #137 as the problem looks the same but I did not look in depth at it.  

