### PR TITLE
use CodecZlib.jl instead of Libz.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,6 @@ Compat 0.42.0
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
 LibExpat 0.2.8
-Libz
+CodecZlib 0.4
 BinDeps 0.3
 SHA

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -9,7 +9,7 @@ if isunix()
     using HTTPClient.HTTPC
 end
 
-using Libz, LibExpat, URIParser
+using CodecZlib, LibExpat, URIParser
 
 import Base: show, getindex, wait_close, pipeline_error
 
@@ -153,7 +153,7 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
                 warn("received error $(data[2]) while downloading $source/$path")
                 return nothing
             end
-            body = gunzip ? Libz.decompress(convert(Vector{UInt8},data[1])) : data[1]
+            body = gunzip ? transcode(GzipDecompressor, convert(Vector{UInt8}, data[1])) : data[1]
             open(path2, "w") do f
                 write(f, body)
             end


### PR DESCRIPTION
I no longer actively maintain Libz.jl. We should use [CodecZlib.jl](https://github.com/bicycle1885/CodecZlib.jl) if possible.