### PR TITLE
Fix try-catch

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -115,6 +115,7 @@ function getcachedir(cachedir, source)
                 try
                     mkdir(cache)
                     break
+                catch
                 end
             end
         end


### PR DESCRIPTION
In Julia 1.0 `try` without `catch` or `finally` throws error.