### PR TITLE
use unescape instead of escape for the cpio files

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -475,7 +475,7 @@ function do_install(package::Package)
     end
     @info("Extracting: ", name)
 
-    cpio = splitext(joinpath(cache, escape(basename(path))))[1] * ".cpio"
+    cpio = splitext(joinpath(cache, unescape(basename(path))))[1] * ".cpio"
 
     local err = nothing
     for cmd = [`$exe7z x -y $path2 -o$cache`, `$exe7z x -y $cpio -o$installdir`]


### PR DESCRIPTION
This is a possible solution to #161

Example: Building "Cbc" 

downloaded files to the cache are:

- noarch%2Fmingw64-Cbc-2.9.2-1.19.noarch.rpm
- noarch%2Fmingw64-Clp-1.16.3-1.21.noarch.rpm
- noarch%2Fmingw64-libCgl1-0.59.2-3.20.noarch.rpm
- noarch%2Fmingw64-libCoinUtils3-2.10.3-2.21.noarch.rpm
- noarch%2Fmingw64-libstdc%2B%2B6-8.2.0-2.1.noarch.rpm
- noarch%2Fmingw64-libwinpthread1-5.0.3-1.13.noarch.rpm
- noarch%2Fmingw64-Osi-0.107.2-2.21.noarch.rpm
- repodata%2F6c3cf735 ... b38cb-primary.xml
- repodata%2Frepomd.xml

7z extracts `noarch%2Fmingw64-libstdc%2B%2B6-8.2.0-2.1.noarch.rpm` 
to `mingw64-libstdc++6-8.2.0-2.1.noarch.cpio`

so the filename has to be unescaped, instead of escaped. 

But I am not sure if the files should have escaped file names in the first place.... 