### PR TITLE
Use Base.download() on Windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,31 @@
+using Base.CoreLogging
+using Test
+using WinRPM
+
+@testset "WinRPM" begin
+    @testset "download(); 200" begin
+        uri = "https://raw.githubusercontent.com/JuliaPackaging/WinRPM.jl/v0.4.2/sources.list"
+        expected = [
+            "https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.2",
+            "https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.2",
+            "",
+        ]
+        content, code = WinRPM.download(uri)
+        @test code == 200
+        actual = split(content, "\n")
+        @test length(actual) == length(expected)
+        for i = 1:length(actual)
+            @test (i, actual[i]) == (i, expected[i])
+        end
+    end
+
+    @testset "download(); 404" begin
+        uri = "https://raw.githubusercontent.com/JuliaPackaging/WinRPM.jl/v0.4.2/no_such_file"
+        content, code = "!", -1
+        with_logger(NullLogger()) do
+            content, code = WinRPM.download(uri)
+        end
+        #@test code == 404  # URLDownloadToCacheFileW version does not return this properly
+        @test content == ""
+    end
+end


### PR DESCRIPTION
This PR let WinRPM to use `Base.download()` on Windows.

1. Download the data into a temporary file of which name is unique
2. Once we create a temporary file, we close it before using it as a download destination
   - Otherwise PowerShell version of Base.download() fails (because of `ERROR_SHARING_VIOLATION` I guess but not confirmed)
3. Since the new logic uses already created (an existing) file as a download destination, now we check whether it succeeds or not by whether the file size increased or not
4. Finally we should remove the temporary file not only when the download succeeds but also when it failed

I have confirmed this logic works fine using Julia 0.7, 1.0, 1.1 and 1.2rc2 on Windows 10 under a proxy server which requires an authentication.