### PR TITLE
Switch to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,18 @@
+name = "WinRPM"
+uuid = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
+version = "0.4.2"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+HTTPClient = "0862f596-cf2d-50af-8ef4-f2be67dfa83f"
+LibExpat = "522f3ed2-3f36-55e3-b6df-e94fee9b0c07"
+Libz = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
+URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+
+[compat]
+BinDeps = "≥0.3"
+Compat = "≥0.42"
+LibExpat = "≥0.2.8"
+URIParser = "≥0.0.3"
+julia = "1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,0 @@
-julia 0.7-rc3
-Compat 0.42.0
-URIParser 0.0.3
-@unix HTTPClient 0.0.0
-LibExpat 0.2.8
-Libz
-BinDeps 0.3


### PR DESCRIPTION
I haven't touched the version here as I'm not sure what you want to call the new release. 

I also wasn't sure what to do with the compat - right now it's just the bounds from REQUIRE and I imagine these could probably be updated, but without CI or tests I didn't want to cause any breakage.

FWIW the versions that were resolved locally for me were:
```
BinDeps v1.0.0
Compat v2.2.0
HTTPClient v0.2.1
LibExpat v0.5.0
Libz v1.0.0
URIParser v0.4.0
```

Please feel free to adjust as necessary!