### PR TITLE
Use HTTP instead of HTTPClient, add some tests, and multiple other improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,28 @@
+# Documentation: https://github.com/JuliaCI/Appveyor.jl
+environment:
+  matrix:
+  - julia_version: '1'
+  - julia_version: nightly
+platform:
+  - x86
+  - x64
+matrix:
+  allow_failures:
+    - julia_version: nightly
+branches:
+  only:
+    - master
+    - /release-.*/
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+  - windows
+julia:
+  - "1"
+  - nightly
+matrix:
+  allow_failures:
+    # - julia: nightly
+  fast_finish: true
+notifications:
+  email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,24 @@
 name = "WinRPM"
 uuid = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
-version = "0.4.3"
+version = "1.0.0"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-HTTPClient = "0862f596-cf2d-50af-8ef4-f2be67dfa83f"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LibExpat = "522f3ed2-3f36-55e3-b6df-e94fee9b0c07"
 Libz = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
 BinDeps = "1"
-Compat = "2, 3"
-HTTPClient = "0.1, 0.2"
-LibExpat = "0.5, 0.6"
+HTTP = "0.8"
+LibExpat = "0.6.1"
 Libz = "1"
 URIParser = "0.4"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/sources.list
+++ b/sources.list
@@ -1,2 +1,2 @@
-https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.2
-https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.2
+https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.3
+https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,13 +8,16 @@ using Test
         end
     end
 
-    if Sys.iswindows()
+    if Sys.iswindows() && lowercase(get(ENV, "CI", "")) == "true"
         @testset "WinRPM.install" begin
             WinRPM.update()
-            WinRPM.install("bzip2"; yes = true)
+            pkg = "bzip2"
+            @info("Attempting to install $(pkg)")
+            WinRPM.install(pkg; yes = true)
             @test isfile(WinRPM.installedlist)
             installedlist = read(WinRPM.installedlist, String)
-            @test occursin("bzip2", installedlist)
+            @test occursin(pkg, installedlist)
+            @info("Successfully installed $(pkg)")
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,20 @@
+using WinRPM
+using Test
+
+@testset "WinRPM.jl" begin
+    @testset "WinRPM.update" begin
+        for (ignorecache, allow_remote) in [(false, true), (true, true)]
+            WinRPM.update(ignorecache, allow_remote)
+        end
+    end
+
+    if Sys.iswindows()
+        @testset "WinRPM.install" begin
+            WinRPM.update()
+            WinRPM.install("bzip2"; yes = true)
+            @test isfile(WinRPM.installedlist)
+            installedlist = read(WinRPM.installedlist, String)
+            @test occursin("bzip2", installedlist)
+        end
+    end
+end


### PR DESCRIPTION
Fixes #176 

This pull request makes the following changes:
1. Adds `HTTP.jl` as a dependency.
2. On Unix-like platforms, uses `HTTP.jl` for downloads.
3. Removes `HTTPClient.jl` as a dependency. (The `HTTPClient.jl` package has been deprecated.)
4. Removes `Compat.jl` as a dependency.
5. Adds the `Test` stdlib as a test-only dependency.
6. Creates the file `test/runtest.jl` file (previously it did not exist). 
7. Adds a few tests (previously, this package did not have any tests).
8. Creates the file `.travis.yml` file (previously it did not exist).
9. Creates the file `.appveyor.yml` file (previously it did not exist).