### PR TITLE
Update sources.list

### DIFF
--- a/sources.list
+++ b/sources.list
@@ -1,2 +1,2 @@
-https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_42.3
-https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_42.3
+https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_Leap_15.3
+https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_Leap_15.3


### PR DESCRIPTION
Repository URLs referencing Leap 42.3 are no longer valid. Change it to 15.3, which is available and should remain so for some reasonable time.